### PR TITLE
fix: treat empty jsonataExpression as null to prevent validation error

### DIFF
--- a/internal/provider/webhook_resource_sdk.go
+++ b/internal/provider/webhook_resource_sdk.go
@@ -415,11 +415,10 @@ func (r *WebhookResourceModel) ToSharedWebhookConfigInput(ctx context.Context) (
 	} else {
 		httpMethod1 = nil
 	}
-	jsonataExpression := new(string)
-	if !r.JsonataExpression.IsUnknown() && !r.JsonataExpression.IsNull() {
-		*jsonataExpression = r.JsonataExpression.ValueString()
-	} else {
-		jsonataExpression = nil
+	var jsonataExpression *string
+	if !r.JsonataExpression.IsUnknown() && !r.JsonataExpression.IsNull() && r.JsonataExpression.ValueString() != "" {
+		val := r.JsonataExpression.ValueString()
+		jsonataExpression = &val
 	}
 	var multipartConfig *shared.MultipartConfig
 	if r.MultipartConfig != nil {

--- a/internal/provider/webhook_resource_sdk_test.go
+++ b/internal/provider/webhook_resource_sdk_test.go
@@ -2,8 +2,11 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/epilot-dev/terraform-provider-epilot-webhook/internal/sdk/models/shared"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -58,5 +61,46 @@ func TestToSharedWebhookConfigInput_EmptyJsonataExpression(t *testing.T) {
 				t.Errorf("expected JsonataExpression to be %q, got %q", tt.jsonataExpr.ValueString(), *result.JsonataExpression)
 			}
 		})
+	}
+}
+
+func TestRefreshThenUpdate_EmptyJsonataNotSentInJSON(t *testing.T) {
+	// Simulate what happens when API returns empty string for jsonataExpression
+	// then we update the webhook - the empty string should NOT appear in the JSON payload
+
+	// Step 1: Simulate API response with empty jsonataExpression
+	emptyStr := ""
+	apiResponse := &shared.WebhookConfig{
+		Name:              "test-webhook",
+		EventName:         "EntityCreated",
+		JsonataExpression: &emptyStr, // API returns empty string
+	}
+
+	// Step 2: Refresh model from API response
+	model := &WebhookResourceModel{}
+	diags := model.RefreshFromSharedWebhookConfig(context.Background(), apiResponse)
+	if diags.HasError() {
+		t.Fatalf("refresh failed: %v", diags)
+	}
+
+	// Step 3: Convert back to API request (as would happen during update)
+	result, diags := model.ToSharedWebhookConfigInput(context.Background())
+	if diags.HasError() {
+		t.Fatalf("conversion failed: %v", diags)
+	}
+
+	// Step 4: Verify jsonataExpression is nil (won't be sent due to omitempty)
+	if result.JsonataExpression != nil {
+		t.Errorf("expected JsonataExpression to be nil after refresh from empty string, got %q", *result.JsonataExpression)
+	}
+
+	// Step 5: Verify JSON serialization doesn't include jsonataExpression
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("JSON marshal failed: %v", err)
+	}
+
+	if strings.Contains(string(jsonBytes), "jsonataExpression") {
+		t.Errorf("JSON should not contain jsonataExpression field, got: %s", string(jsonBytes))
 	}
 }

--- a/internal/provider/webhook_resource_sdk_test.go
+++ b/internal/provider/webhook_resource_sdk_test.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestToSharedWebhookConfigInput_EmptyJsonataExpression(t *testing.T) {
+	tests := []struct {
+		name           string
+		jsonataExpr    types.String
+		expectNil      bool
+	}{
+		{
+			name:        "null jsonata expression should be nil",
+			jsonataExpr: types.StringNull(),
+			expectNil:   true,
+		},
+		{
+			name:        "unknown jsonata expression should be nil",
+			jsonataExpr: types.StringUnknown(),
+			expectNil:   true,
+		},
+		{
+			name:        "empty string jsonata expression should be nil",
+			jsonataExpr: types.StringValue(""),
+			expectNil:   true,
+		},
+		{
+			name:        "valid jsonata expression should not be nil",
+			jsonataExpr: types.StringValue("$.entity.name"),
+			expectNil:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := &WebhookResourceModel{
+				Name:              types.StringValue("test-webhook"),
+				EventName:         types.StringValue("EntityCreated"),
+				JsonataExpression: tt.jsonataExpr,
+			}
+
+			result, diags := model.ToSharedWebhookConfigInput(context.Background())
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+
+			if tt.expectNil && result.JsonataExpression != nil {
+				t.Errorf("expected JsonataExpression to be nil, got %q", *result.JsonataExpression)
+			}
+			if !tt.expectNil && result.JsonataExpression == nil {
+				t.Error("expected JsonataExpression to not be nil, got nil")
+			}
+			if !tt.expectNil && result.JsonataExpression != nil && *result.JsonataExpression != tt.jsonataExpr.ValueString() {
+				t.Errorf("expected JsonataExpression to be %q, got %q", tt.jsonataExpr.ValueString(), *result.JsonataExpression)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- When updating webhooks without a JSONata expression, an empty string `""` was being sent to the API, causing "Invalid JSONata expression" validation errors
- The fix treats empty strings the same as null values - they are now omitted from the request payload entirely
- Added unit tests that verify the fix works for the full refresh-then-update flow

## Root Cause

The old code only checked for `IsNull()` and `IsUnknown()`:
```go
if !r.JsonataExpression.IsUnknown() && !r.JsonataExpression.IsNull() {
    *jsonataExpression = r.JsonataExpression.ValueString()
}
```

When the API returns `jsonataExpression: ""` (empty string), this would pass through and be serialized as `"jsonataExpression":""` in the JSON payload, which the API then validates as invalid.

## Test Plan

- [x] Unit tests pass - including new test that simulates API returning empty string, refreshing model, then converting back to request
- [x] Verified JSON serialization does NOT contain `jsonataExpression` field when value is empty
- [x] Build succeeds

## Slack Thread

https://epilot.slack.com/archives/C0ADDKKTLVD/p1779778792063759

https://claude.ai/code/session_0115id4bjLGsZZKAZQ1wXvtr

---
_Generated by [Claude Code](https://claude.ai/code/session_0115id4bjLGsZZKAZQ1wXvtr)_